### PR TITLE
chore: set engines.node to 20.x for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": "20.x"
+  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.600.0",
     "dotenv": "^17.2.2",


### PR DESCRIPTION
Add `engines.node=20.x` so Vercel uses Node 20 for builds. You also need to set Node.js Version to 20.x in the Vercel Project Settings to resolve the deploy error.