### PR TITLE
chore: ignore .swc and .turbo caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ uploads/videos/**/*.webm
 uploads/temp/*
 !uploads/temp/.gitkeep
 .vercel
+.swc/
+.turbo/


### PR DESCRIPTION
Add .swc/ and .turbo/ to .gitignore so local compiler caches are not tracked.