### PR TITLE
fix: prevent disk space caching issues

### DIFF
--- a/app/api/disk-space/route.ts
+++ b/app/api/disk-space/route.ts
@@ -6,11 +6,20 @@ export async function GET() {
     const diskSpace = DiskSpaceManager.getReadableDiskSpace();
     const warning = DiskSpaceManager.getDiskSpaceWarning();
 
-    return NextResponse.json({
-      success: true,
-      diskSpace,
-      warning,
-    });
+    return NextResponse.json(
+      {
+        success: true,
+        diskSpace,
+        warning,
+      },
+      {
+        headers: {
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+          Pragma: 'no-cache',
+          Expires: '0',
+        },
+      }
+    );
   } catch (error) {
     console.error('Disk space check error:', error);
 

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -46,8 +46,13 @@ export default function UploadPage() {
 
   // Load disk space info and FFmpeg status on component mount
   useEffect(() => {
-    // Load disk space
-    fetch('/api/disk-space')
+    // Load disk space with cache busting
+    fetch('/api/disk-space', {
+      cache: 'no-store',
+      headers: {
+        'Cache-Control': 'no-cache',
+      },
+    })
       .then((res) => res.json())
       .then((data) => {
         if (data.success) {


### PR DESCRIPTION
## Problem
The disk space indicator on production shows stale/cached values (e.g., 21.68 GB, 70% used) instead of actual server disk space.

## Solution
- Added no-cache headers to the /api/disk-space response
- Added cache-busting to client-side fetch request
- Ensures accurate real-time disk space reporting

## Result
- Production will now show correct disk space values
- No more cached/stale disk space information
- Consistent behavior between local dev and production