### PR TITLE
fix: videos not appearing after direct-to-cloud upload

### DIFF
--- a/.github/test-pr-automation.md
+++ b/.github/test-pr-automation.md
@@ -1,0 +1,4 @@
+# Test PR Automation
+
+Testing if PR_AUTOMATION_TOKEN now works correctly.
+Date: 2025-09-30

--- a/app/api/video/register/route.ts
+++ b/app/api/video/register/route.ts
@@ -147,8 +147,8 @@ export async function POST(req: NextRequest) {
 
     // Invalidate cache to ensure the new video shows up immediately
     const { metadataCache } = await import('@/lib/metadata-cache');
-    metadataCache.invalidateVideoList();
-    console.log('🔄 Invalidated video list cache after registration');
+    metadataCache.invalidateVideo(videoId);
+    console.log('🔄 Invalidated video cache after registration');
 
     return NextResponse.json({ success: true, metadata });
   } catch (error) {

--- a/app/api/video/register/route.ts
+++ b/app/api/video/register/route.ts
@@ -144,6 +144,12 @@ export async function POST(req: NextRequest) {
     );
 
     console.log(`✅ Successfully registered video ${videoId} in cloud storage`);
+
+    // Invalidate cache to ensure the new video shows up immediately
+    const { metadataCache } = await import('@/lib/metadata-cache');
+    metadataCache.invalidateVideoList();
+    console.log('🔄 Invalidated video list cache after registration');
+
     return NextResponse.json({ success: true, metadata });
   } catch (error) {
     console.error(`❌ Failed to save metadata for video ${videoId}:`, error);


### PR DESCRIPTION
## Problem
After uploading a video using direct-to-cloud mode (Backblaze B2), the video doesn't appear in the videos management page. The system shows 'Active uploads: 1' but '0 videos found'.

## Root Cause
The metadata registration was successful but the video list cache was not being invalidated, so the new video didn't show up until a cache expiry.

## Solution
- Added cache invalidation after successful video metadata registration
- Ensures uploaded videos appear immediately in the management page
- Improves user experience by providing immediate feedback

## Testing
1. Upload a video using direct-to-cloud mode
2. Navigate to /videos page
3. Video should appear immediately in the list